### PR TITLE
Fix conditional test Rockwell/WDC opcodes

### DIFF
--- a/65C02_extended_opcodes_test.a65c
+++ b/65C02_extended_opcodes_test.a65c
@@ -63,6 +63,7 @@
 ;   16-aug-2013  added error report to standard output option
 ;   23-aug-2015  change revoked
 ;   24-aug-2015  all self modifying immediate opcodes now execute in data RAM
+;   09-feb-2017  fixed RMB/SMB tested when they shouldn't be tested
 
 
 ; C O N F I G U R A T I O N

--- a/65C02_extended_opcodes_test.a65c
+++ b/65C02_extended_opcodes_test.a65c
@@ -1867,7 +1867,7 @@ tbt2
         trap_ne     ;sp push/pop mismatch
         next_test    
 
-    if rkwl_wdc_op
+    if rkwl_wdc_op = 1
 ; testing RMB, SMB - zp
 rmbt    macro       ;\1 = bitnum
         lda #$ff


### PR DESCRIPTION
Test comments indicated that having rkwl_wdc_op set to > 1 means
no test, but there was conditional that was just checking
that the value was not 0 and thereby causing those opcodes
to be tests when this value was set to > 1